### PR TITLE
Added `getInputRef` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ container | Object | `{}` | Define the props of the container `div`. All props e
 inputField | Object | `{}` | Define the props of the `input` element. See `container` for more details.
 characters | Object | `{}` | Define the props of the characters `div`. See `container` for more details.
 character | Object | `{}` | Define the props of the character `div`s. See `container` for more details.
+getInputRef | Function | `() => {}` | Define a function that will receive input element `ref`.
 
 ## Custom styling
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ export default class VerificationInput extends PureComponent {
     inputField: {},
     characters: {},
     character: {},
+    getInputRef: () => {},
   };
 
   constructor(props) {
@@ -81,10 +82,7 @@ export default class VerificationInput extends PureComponent {
 
   saveInputRef = ref => {
     this.input = ref
-    
-    if (this.props.getInputRef) {
-      this.props.getInputRef(ref)
-    }
+    this.props.getInputRef(ref)
   }
 
   handleChange(tan, selectedIndex) {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default class VerificationInput extends PureComponent {
     autoFocus: PropTypes.bool,
     removeDefaultStyles: PropTypes.bool,
     debug: PropTypes.bool,
+    getInputRef: PropTypes.func,
     container: PropTypes.shape({
       className: PropTypes.string,
     }),
@@ -76,6 +77,14 @@ export default class VerificationInput extends PureComponent {
   // negative offset = move to the left
   moveSelectionBy(offset) {
     this.setSelection(this.state.selectedIndex + offset);
+  }
+
+  saveInputRef = ref => {
+    this.input = ref
+    
+    if (this.props.getInputRef) {
+      this.props.getInputRef(ref)
+    }
   }
 
   handleChange(tan, selectedIndex) {
@@ -244,7 +253,7 @@ export default class VerificationInput extends PureComponent {
         {...containerProps}
       >
         <input
-          ref={(input) => this.input = input}
+          ref={this.saveInputRef}
           className={classNames('verification-input', inputClassName, {
             'verification-input--debug': debug,
           })}


### PR DESCRIPTION
Hey @andreaswilli, thanks for a great library!

I need to get an input ref to be able to reset its value depending on the flow in my app. It seems that it's not possible at the moment. This PR adds an ability to access input prop outside of the component.